### PR TITLE
Update minimum libpq version to delight travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/brianc/node-pg-native",
   "dependencies": {
-    "libpq": "^1.5.0",
+    "libpq": "^1.6.3",
     "pg-types": "1.6.0",
     "readable-stream": "1.0.31"
   },


### PR DESCRIPTION
Travis uses the youngest possible version instead of the newest. This fixes the issue with nan being to old for iojs 2.0