### PR TITLE
Added libpq escapeLiteral and escapeIdentifier wrappers

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,5 +279,13 @@ Client.prototype.executeSync = function(statementName, parameters) {
   return this._parseResults(this.pq, []);
 };
 
+Client.prototype.escapeLiteral = function(value) {
+  return this.pq.escapeLiteral(value);
+};
+
+Client.prototype.escapeIdentifier = function(value) {
+  return this.pq.escapeIdentifier(value);
+};
+
 //export the version number so we can check it in node-postgres
 module.exports.version = require('./package.json').version


### PR DESCRIPTION
For queries with a very large number of parameters ( 20k + ) it is much faster to escape them instead of binding them:
- query sent with inline parameters : ( 20ms )
- query sent with binded parameters ( 440ms )