### PR TITLE
Fix copy stream's COPY_BOTH msg not being handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ Client.prototype._read = function() {
     if(pq.resultStatus() == 'PGRES_TUPLES_OK') {
       this._parseResults(this.pq, rows);
     }
-    if(pq.resultStatus() == 'PGRES_COPY_OUT')  break;
+    if(pq.resultStatus() == 'PGRES_COPY_OUT' || pq.resultStatus() == 'PGRES_COPY_BOTH') break;
   }
 
 
@@ -122,6 +122,7 @@ Client.prototype._read = function() {
     case 'PGRES_COMMAND_OK':
     case 'PGRES_TUPLES_OK':
     case 'PGRES_COPY_OUT':
+    case 'PGRES_COPY_BOTH':
     case 'PGRES_EMPTY_QUERY': {
       this.emit('result', rows);
       break;


### PR DESCRIPTION
- Add copy stream's `PGRES_COPY_BOTH` message handling
- Fix infinite loop on querying PostgreSQL with `START_REPLICATION`
