### PR TITLE
Add pg-types with a floating patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/brianc/node-pg-native",
   "dependencies": {
     "libpq": "^1.7.0",
-    "pg-types": "1.6.0",
+    "pg-types": "^1.12.1",
     "readable-stream": "1.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
I'll manually bump the minor version here whenever I need to bump the minor version of pg-types. This way any _possible_ behavior change from pg-types is indicated here as well w/ the corresponding minor semver bump.