### PR TITLE
Avoid calling done() multiple times

### DIFF
--- a/test/notify.js
+++ b/test/notify.js
@@ -46,9 +46,8 @@ if (!process.env.TRAVIS_CI) {
       client.query('LISTEN test', ok(done, function () {
         notify('test', 'bot')
         client.query('SELECT pg_sleep(.05)', ok(done, function () {
-          check()
+          notify('test', 'bot')
         }))
-        notify('test', 'bot')
       }))
     })
 


### PR DESCRIPTION
The "async LISTEN/NOTIFY" test has recently started failing for me, presumably due to a change in Node.js or something, with:

```
  1) async LISTEN/NOTIFY works:
     Error: done() called multiple times
      at Suite.<anonymous> (test/notify.js:38:5)
      at Object.<anonymous> (test/notify.js:32:3)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:22:18)
      at Array.forEach (<anonymous>)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)
      at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
      at startup (internal/bootstrap/node.js:283:19)
      at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)
```

Examining the test it appears that this complaint is correct, because `check()` is actually three times, once from each notification callback and once directly after the timeout. In turn that means `done()` will be called twice.

This patch removes the direct call to `check()` so that it is only called in response to the two notifications.